### PR TITLE
about/trademark: add back old redirect

### DIFF
--- a/content/about/trademark.html
+++ b/content/about/trademark.html
@@ -4,6 +4,7 @@ section: "about"
 subsection: "trademark"
 subtitle: "Trademark"
 display_class: "one-line"
+aliases: "../trademark"
 ---
 <section class="about current" id="trademark">
 


### PR DESCRIPTION
git-scm.com/trademark redirects to git-scm.com/about/trademark on the rails version of the site. Add this redirect back to the hugo version.

~~Note: I haven't tested this locally, yet, as my `hugo` doesn't want to serve the website locally.~~ I have now got my hugo working. This works as intended.