### PR TITLE
downloads/mac: fix grammar

### DIFF
--- a/content/downloads/mac.html
+++ b/content/downloads/mac.html
@@ -38,7 +38,7 @@ aliases:
         let ago = "" + daysAgo + " days ago"
 
         const handwave = (exact, unit) => {
-          const rest = (count) => "" + count + " " + unit + (count > 1 ? "s" : "") + " ago"
+          const rest = count => `${count} ${unit}${count > 1 ? "s" : ""} ago`
 
           const roundedDown = Math.floor(exact)
           const fract = exact - roundedDown

--- a/content/downloads/mac.html
+++ b/content/downloads/mac.html
@@ -38,7 +38,7 @@ aliases:
         let ago = "" + daysAgo + " days ago"
 
         const handwave = (exact, unit) => {
-          const rest = (count) => "" + count + " " + unit + (unit > 1 ? "s" : "")
+          const rest = (count) => "" + count + " " + unit + (count > 1 ? "s" : "") + " ago"
 
           const roundedDown = Math.floor(exact)
           const fract = exact - roundedDown


### PR DESCRIPTION
## Changes

make the plural check work properly and add the missing word "ago" for years and months.

## Context

https://dscho.github.io/git-scm.com/downloads/mac/ has an odd grammar issue that https://git-scm.com/download/mac doesn't. It says

> which was released about 2 year, on 2021-08-30.

https://git-scm.com/download/mac correctly says

> which was released about 2 years ago, on 2021-08-30.


