### PR TITLE
css: place dark-mode icon next to tagline on mobile

### DIFF
--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -53,24 +53,11 @@ pre {
 }
 
 #dark-mode-button {
+    grid-area: dark;
     display: none;
     width: 28px;
     background-color: transparent;
     text-decoration: none;
     align-self: center;
     margin: 5px;
-}
-
-@media (max-width: $default + 100) {
-    #dark-mode-button {
-        top: 41px;
-        right: 5px;
-    }
-}
-
-@media (max-width: $default) {
-    #dark-mode-button {
-        top: 5px;
-        right: 20px;
-    }
 }

--- a/assets/sass/forms.scss
+++ b/assets/sass/forms.scss
@@ -42,7 +42,7 @@ form#search {
   @include box-shadow(inset 0 1px 4px #ddd);
 
   input {
-    width: 100%;
+    width: calc(100% - 10px);
     height: 20px;
     margin-top: 4px;
     margin-bottom: 2px;

--- a/assets/sass/layout.scss
+++ b/assets/sass/layout.scss
@@ -77,7 +77,6 @@ aside {
 
 #masthead {
   height: 295px;
-  margin-top: -20px;
   margin-bottom: 2em;
   @include background-image-2x($baseurl + "images/bg/isometric-grid", 35px, 21px, top right, repeat);
 
@@ -110,30 +109,22 @@ aside {
 
 // Header
 header {
-  padding-bottom: 26px;
-  margin-top: 14px;
+  padding: 1rem 0;
 
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-areas:  "logo tagline search dark";
+  grid-template-columns: auto 1fr     auto   auto;
+  align-items: center;
 
-  div {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-
-    &:first-child {
-      flex-grow: 4;
-    }
-  }
   #logo {
+    grid-area: logo;
     display: flex;
   }
 
   #tagline {
-    display: block;
-    margin-left: 8px;
+    grid-area: tagline;
+    margin-left: 0.8em;
     font-size: clamp(0.8rem, 2vw, 1.3rem);
-    line-height: 24px;
     color: var(--light-font-color);
 
     em {
@@ -451,10 +442,7 @@ table.benchmarks {
   .responsive-table { overflow-x: auto; }
   .center img { height: 100%; }
   header{
-    a, span {
-      padding-left: 1rem;
-      margin-bottom: 10px ;
-    }
+    padding: 1rem;
   }
   #content { width: 100%; }
   .inner { width: 100%; }
@@ -464,7 +452,6 @@ table.benchmarks {
     height: unset;
     .inner {
       display: flex;
-      margin-top: 1.8rem;
       div:first-of-type {
         padding:1rem;
       }
@@ -489,13 +476,12 @@ table.benchmarks {
 // Mobile
 @media (max-width: $mobile-m) {
   header {
-    padding-bottom: 3rem;
+    grid-template-areas: "logo   tagline dark"
+                         "search search  search";
     #tagline {
       font-size: clamp(0.8rem, 3vw, 1.3rem);
     }
-    flex-direction: column;
   }
-  #home { .inner { > header { padding-bottom: 2.5rem; } } }
   #masthead {
     .inner { flex-direction: column-reverse; }
     .illustration-wrapper {

--- a/assets/sass/search.scss
+++ b/assets/sass/search.scss
@@ -2,6 +2,8 @@
 @import "mixins";
 
 #search-container {
+  grid-area: search;
+  display: flex;
   position: relative;
   width: 300px;
   padding-left: 60px;
@@ -153,10 +155,6 @@ ol.full-search-results {
 @media (max-width: $mobile-m) {
   #search-container {
     width: inherit;
-    margin-left: 15px;
-  }
-  #search-results{
-    margin-top: 4px;
   }
 }
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,29 +1,25 @@
 <header>
-  <div id="brand">
-    <a id="logo" href="{{ relURL "" }}"><img src="{{ relURL "images/logo@2x.png" }}" width="110" height="46" alt="Git" class="no-filter" /></a>
-    <span id="tagline"></span>
-    <script type="text/javascript">
-     const taglines = [
-       "fast-version-control",
-       "everything-is-local",
-       "distributed-even-if-your-workflow-isnt",
-       "local-branching-on-the-cheap",
-       "distributed-is-the-new-centralized"
-     ];
-     var tagline = taglines[Math.floor(Math.random() * taglines.length)];
-     document.getElementById('tagline').innerHTML = '--' + tagline;
-    </script>
-  </div>
+  <a id="logo" href="{{ relURL "" }}"><img src="{{ relURL "images/logo@2x.png" }}" width="110" height="46" alt="Git" class="no-filter" /></a>
+  <span id="tagline"></span>
+  <script type="text/javascript">
+   const taglines = [
+     "fast-version-control",
+     "everything-is-local",
+     "distributed-even-if-your-workflow-isnt",
+     "local-branching-on-the-cheap",
+     "distributed-is-the-new-centralized"
+   ];
+   var tagline = taglines[Math.floor(Math.random() * taglines.length)];
+   document.getElementById('tagline').innerHTML = '--' + tagline;
+  </script>
 
-  <div>
-    {{ if ne (.Scratch.Get "section") "search" }}
-    <div id="search-container">
-      <form id="search" action="{{ relURL "search/results" }}">
-        <input id="search-text" name="search" placeholder="Type / to search entire site…" autocomplete="off" type="text" />
-      </form>
-      <div id="search-results"></div>
-    </div>
-    {{ end }}
-    <img src="{{ relURL "images/dark-mode.svg" }}" id="dark-mode-button" />
+  {{ if ne (.Scratch.Get "section") "search" }}
+  <div id="search-container">
+    <form id="search" action="{{ relURL "search/results" }}">
+      <input id="search-text" name="search" placeholder="Type / to search entire site…" autocomplete="off" type="text" />
+    </form>
+    <div id="search-results"></div>
   </div>
+  {{ end }}
+  <img src="{{ relURL "images/dark-mode.svg" }}" id="dark-mode-button" />
 </header>


### PR DESCRIPTION
Because it looks better to have the whole width for the search bar on mobile, move the dark-mode icon above the search bar, next to the tagline. To achieve this, use CSS grid where we can name the grid-areas and reposition them within media queries.

### Screenshots

| | Without search | With search |
|-|-|-|
| Mobile | ![Screen Shot 2025-03-19 at 14 53 36](https://github.com/user-attachments/assets/01bc642f-57da-4506-9386-9bb08569d30f) | ![Screen Shot 2025-03-19 at 14 53 30](https://github.com/user-attachments/assets/a5b9f103-d805-4da9-9fcf-dc95da7bd23a) |
| Tablet (portrait) | ![Screen Shot 2025-03-19 at 14 53 20](https://github.com/user-attachments/assets/dd289a09-f0fb-40db-817d-eea6870e468e) | ![Screen Shot 2025-03-19 at 14 53 26](https://github.com/user-attachments/assets/36c1ac4a-2f2a-4180-b537-23e82d6e6b43) |
| Tablet (landscape) | ![Screen Shot 2025-03-19 at 14 53 13](https://github.com/user-attachments/assets/b10fe889-860d-4d88-89ed-8506b9d3769b) | ![Screen Shot 2025-03-19 at 14 53 08](https://github.com/user-attachments/assets/720e46fb-fa1e-4b15-9b8f-14e906f56552) |
| Desktop | ![Screen Shot 2025-03-19 at 14 52 48](https://github.com/user-attachments/assets/e6f3a884-6547-4f29-9b1d-4fe298f6bf5d) | ![Screen Shot 2025-03-19 at 14 53 00](https://github.com/user-attachments/assets/180562c6-e3ed-4f37-b613-4c9a262c9211) |
